### PR TITLE
Add basic unit tests for core functionality

### DIFF
--- a/AgendaFit.Tests/AgendaFit.Tests.csproj
+++ b/AgendaFit.Tests/AgendaFit.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Aplicacao\Aplicacao.csproj" />
+    <ProjectReference Include="..\Dominio\Dominio.csproj" />
+    <ProjectReference Include="..\Infra\Infra.csproj" />
+    <ProjectReference Include="..\Repositorio\Repositorio.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.8" />
+  </ItemGroup>
+
+</Project>

--- a/AgendaFit.Tests/Aplicacao/AplicBaseTests.cs
+++ b/AgendaFit.Tests/Aplicacao/AplicBaseTests.cs
@@ -1,0 +1,54 @@
+using Aplicacao.Base;
+using Dominio.Cadastros.Alunos;
+using Moq;
+using Repositorio.Base;
+using Xunit;
+
+namespace AgendaFit.Tests.Aplicacao
+{
+    public class AplicBaseTests
+    {
+        private class AplicBaseFake : AplicBase<Aluno>
+        {
+            public AplicBaseFake(IRepBase<Aluno> repositorio) : base(repositorio) { }
+        }
+
+        [Fact]
+        public void Inserir_DeveChamarRepositorioESalvar()
+        {
+            var repoMock = new Mock<IRepBase<Aluno>>();
+            var aplicacao = new AplicBaseFake(repoMock.Object);
+            var aluno = new Aluno { Nome = "Maria" };
+
+            aplicacao.Inserir(aluno);
+
+            repoMock.Verify(r => r.Inserir(aluno), Times.Once);
+            repoMock.Verify(r => r.SaveChanges(), Times.Once);
+        }
+
+        [Fact]
+        public void Alterar_DeveChamarRepositorioESalvar()
+        {
+            var repoMock = new Mock<IRepBase<Aluno>>();
+            var aplicacao = new AplicBaseFake(repoMock.Object);
+            var aluno = new Aluno { Nome = "Maria" };
+
+            aplicacao.Alterar(1, aluno);
+
+            repoMock.Verify(r => r.Alterar(1, aluno), Times.Once);
+            repoMock.Verify(r => r.SaveChanges(), Times.Once);
+        }
+
+        [Fact]
+        public void Remover_DeveChamarRepositorioESalvar()
+        {
+            var repoMock = new Mock<IRepBase<Aluno>>();
+            var aplicacao = new AplicBaseFake(repoMock.Object);
+
+            aplicacao.Remover(1);
+
+            repoMock.Verify(r => r.Remover(1), Times.Once);
+            repoMock.Verify(r => r.SaveChanges(), Times.Once);
+        }
+    }
+}

--- a/AgendaFit.Tests/Infra/ExtensaoDateTimeTests.cs
+++ b/AgendaFit.Tests/Infra/ExtensaoDateTimeTests.cs
@@ -1,0 +1,27 @@
+using System;
+using Infra.Extensoes;
+using Xunit;
+
+namespace AgendaFit.Tests.Infra
+{
+    public class ExtensaoDateTimeTests
+    {
+        [Fact]
+        public void PrimeiroDiaDoMes_RetornaPrimeiroDia()
+        {
+            var data = new DateTime(2024, 3, 15);
+            var resultado = data.PrimeiroDiaDoMes();
+
+            Assert.Equal(new DateTime(2024, 3, 1), resultado);
+        }
+
+        [Fact]
+        public void UltimoDiaDoMes_RetornaUltimoDia()
+        {
+            var data = new DateTime(2024, 2, 15);
+            var resultado = data.UltimoDiaDoMes();
+
+            Assert.Equal(new DateTime(2024, 2, 29), resultado);
+        }
+    }
+}

--- a/AgendaFit.Tests/Repositorio/RepBaseTests.cs
+++ b/AgendaFit.Tests/Repositorio/RepBaseTests.cs
@@ -1,0 +1,59 @@
+using System;
+using Dominio.Cadastros.Alunos;
+using Microsoft.EntityFrameworkCore;
+using Repositorio.Base;
+using Repositorio.Contexto;
+using Xunit;
+
+namespace AgendaFit.Tests.Repositorio
+{
+    public class RepBaseTests
+    {
+        private RepBase<Aluno> CriarRepositorio(string nomeDb)
+        {
+            var options = new DbContextOptionsBuilder<ContextoBanco>()
+                .UseInMemoryDatabase(nomeDb)
+                .Options;
+            var contexto = new ContextoBanco(options);
+            return new RepBase<Aluno>(contexto);
+        }
+
+        [Fact]
+        public void RecuperarPorIdObrigatorio_QuandoExiste_RetornaEntidade()
+        {
+            var repositorio = CriarRepositorio(nameof(RecuperarPorIdObrigatorio_QuandoExiste_RetornaEntidade));
+            var aluno = new Aluno { Nome = "Joao" };
+            repositorio.Inserir(aluno);
+            repositorio.SaveChanges();
+
+            var resultado = repositorio.RecuperarPorIdObrigatorio(aluno.Id);
+
+            Assert.Equal("Joao", resultado.Nome);
+        }
+
+        [Fact]
+        public void RecuperarPorIdObrigatorio_QuandoNaoExiste_DisparaExcecao()
+        {
+            var repositorio = CriarRepositorio(nameof(RecuperarPorIdObrigatorio_QuandoNaoExiste_DisparaExcecao));
+
+            Assert.Throws<Exception>(() => repositorio.RecuperarPorIdObrigatorio(999));
+        }
+
+        [Fact]
+        public void Alterar_AtualizaValores()
+        {
+            var repositorio = CriarRepositorio(nameof(Alterar_AtualizaValores));
+            var aluno = new Aluno { Nome = "Antigo" };
+            repositorio.Inserir(aluno);
+            repositorio.SaveChanges();
+
+            var atualizado = new Aluno { Nome = "Novo" };
+            repositorio.Alterar(aluno.Id, atualizado);
+            repositorio.SaveChanges();
+
+            var recuperado = repositorio.RecuperarPorId(aluno.Id);
+            Assert.NotNull(recuperado);
+            Assert.Equal("Novo", recuperado!.Nome);
+        }
+    }
+}

--- a/AgendaFit.sln
+++ b/AgendaFit.sln
@@ -21,6 +21,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Infra", "Infra\Infra.csproj
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mvc", "Mvc\Mvc.csproj", "{49A22FD4-FC39-D5A1-2992-E6C456843950}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgendaFit.Tests", "AgendaFit.Tests\AgendaFit.Tests.csproj", "{573872FB-97E0-458C-9FC9-F5B2D244A266}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -47,6 +49,10 @@ Global
 		{49A22FD4-FC39-D5A1-2992-E6C456843950}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{49A22FD4-FC39-D5A1-2992-E6C456843950}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{49A22FD4-FC39-D5A1-2992-E6C456843950}.Release|Any CPU.Build.0 = Release|Any CPU
+                {573872FB-97E0-458C-9FC9-F5B2D244A266}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {573872FB-97E0-458C-9FC9-F5B2D244A266}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {573872FB-97E0-458C-9FC9-F5B2D244A266}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {573872FB-97E0-458C-9FC9-F5B2D244A266}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- Add `AgendaFit.Tests` project with xUnit setup and dependencies
- Verify date extension helpers return first and last day of a month
- Ensure repository and application layers handle persistence operations correctly

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeed4a6e6483269fc579e9b2d19c6a